### PR TITLE
fix(datastore): Fixes passkey compatibility with API

### DIFF
--- a/internal/provider/datastore.go
+++ b/internal/provider/datastore.go
@@ -11,6 +11,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -40,10 +43,16 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"id": schema.StringAttribute{
 				MarkdownDescription: "The ID of the datastore.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"created_at": schema.Int64Attribute{
 				MarkdownDescription: "The timestamp when the datastore was created.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
 			},
 			"disable_pass_key": schema.BoolAttribute{
 				MarkdownDescription: "Disable the passkey for the datastore.",
@@ -59,10 +68,16 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				Required:            false,
 				Computed:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"addr": schema.StringAttribute{
 				MarkdownDescription: "The address of the datastore.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"name": schema.StringAttribute{
 				MarkdownDescription: "The name of the datastore.",
@@ -134,31 +149,49 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 				MarkdownDescription: "Dragonfly-specific configuration.",
 				Optional:            true,
 				Computed:            true,
+				PlanModifiers: []planmodifier.Object{
+					objectplanmodifier.UseStateForUnknown(),
+				},
 				Attributes: map[string]schema.Attribute{
 					"cache_mode": schema.BoolAttribute{
 						MarkdownDescription: "Enable cache mode for memory management.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"bullmq": schema.BoolAttribute{
 						MarkdownDescription: "Enable BullMQ compatibility.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"tls": schema.BoolAttribute{
 						MarkdownDescription: "Enable TLS.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"sidekiq": schema.BoolAttribute{
 						MarkdownDescription: "Enable Sidekiq compatibility.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"memcached": schema.BoolAttribute{
 						MarkdownDescription: "Enable Memcached protocol.",
 						Optional:            true,
 						Computed:            true,
+						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
+						},
 					},
 					"acl_rules": schema.ListAttribute{
 						MarkdownDescription: "List of ACL rules.",
@@ -166,6 +199,9 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Optional:            true,
 						Computed:            true,
 						Sensitive:           true,
+						PlanModifiers: []planmodifier.List{
+							listplanmodifier.UseStateForUnknown(),
+						},
 					},
 				},
 			},

--- a/internal/resource_model/datastore.go
+++ b/internal/resource_model/datastore.go
@@ -94,6 +94,7 @@ func (d *Datastore) FromConfig(ctx context.Context, in *dfcloud.Datastore) {
 	}
 
 	aclRules, _ := types.ListValueFrom(ctx, types.StringType, in.Config.Dragonfly.AclRules)
+
 	d.Dragonfly = types.ObjectValueMust(map[string]attr.Type{
 		"cache_mode": types.BoolType,
 		"tls":        types.BoolType,
@@ -144,7 +145,7 @@ func IntoDatastoreConfig(in Datastore) *dfcloud.Datastore {
 		datastore.Config.NetworkID = in.NetworkId.ValueString()
 	}
 
-	if in.DisablePassKey.ValueBool() {
+	if in.DisablePassKey.ValueBool() && in.Password.IsUnknown() {
 		datastore.Config.DisablePasskey = in.DisablePassKey.ValueBool()
 	}
 
@@ -177,9 +178,7 @@ func IntoDatastoreConfig(in Datastore) *dfcloud.Datastore {
 
 	if in.Dragonfly.Attributes()["acl_rules"] != nil {
 		var rules dfcloud.AclRuleArray
-		for _, rule := range in.Dragonfly.Attributes()["acl_rules"].(types.List).Elements() {
-			rules = append(rules, rule.String())
-		}
+		in.Dragonfly.Attributes()["acl_rules"].(types.List).ElementsAs(context.Background(), &rules, false)
 		datastore.Config.Dragonfly.AclRules = &rules
 	}
 


### PR DESCRIPTION
closes https://github.com/dragonflydb/terraform-provider-dfcloud/issues/28

- [x] Fixes datastore updates with disable passkey enabled
- [x] Fixes acl rules 
- [x] Improves user experience on update. Reduces amount of computed attributes changes.