### PR TITLE
fix(connection): Make Region optional during import

### DIFF
--- a/internal/resource_model/connection.go
+++ b/internal/resource_model/connection.go
@@ -68,7 +68,7 @@ func FromConnectionConfig(in *dfcloud.Connection) *Connection {
 	peer := &PeerConfigModel{
 		AccountID:              types.StringValue(in.Config.Peer.AccountID),
 		VPCID:                  types.StringValue(in.Config.Peer.VPCID),
-		Region:                 types.StringValue(in.Config.Peer.Region),
+		Region:                 optionalString(in.Config.Peer.Region),
 		AzureResourceGroup:     optionalString(az.ResourceGroup),
 		AzureTenantID:          optionalString(az.TenantID),
 		AzureAppObjectID:       optionalString(az.AppObjectID),


### PR DESCRIPTION
It's optional during creation and read, so should be optional during import as well, otherwise requires to have `region = ""`.
Will add coverage in the separate pr, tested manually.