### PR TITLE
fix(ssd): Ensure no replacement in case undefined

### DIFF
--- a/internal/provider/datastore.go
+++ b/internal/provider/datastore.go
@@ -152,6 +152,7 @@ func (r *datastoreResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 						Optional:            true,
 						Computed:            true,
 						PlanModifiers: []planmodifier.Bool{
+							boolplanmodifier.UseStateForUnknown(),
 							boolplanmodifier.RequiresReplace(),
 						},
 					},


### PR DESCRIPTION
Fixes 

```
Terraform will perform the following actions:

  # dfcloud_datastore.cache must be replaced
-/+ resource "dfcloud_datastore" "cache" {
      ~ addr       = "xitsd7hg8.dev.dragonflydb.cloud:6385" -> (known after apply)
      ~ created_at = 1787218646 -> (known after apply)
      ~ dragonfly  = {
          ~ acl_rules  = (sensitive value)
          ~ bullmq     = false -> (known after apply)
          ~ memcached  = false -> (known after apply)
          ~ sidekiq    = false -> (known after apply)
          ~ tls        = false -> (known after apply)
            # (1 unchanged attribute hidden)
        }
      ~ id         = "dst_xitsd7hg8" -> (known after apply)
        name       = "frontend-cache"
      ~ password   = (sensitive value)
      ~ tier       = {
          ~ max_memory_bytes            = 6250000000 -> 1250000000
          ~ ssd                         = false -> (known after apply) # forces replacement
            # (3 unchanged attributes hidden)
        }
        # (1 unchanged attribute hidden)
    }
```

on update